### PR TITLE
Remove confusing header navigation and fix repeated titles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # GitHub Pages Configuration for Devin Wiki
 
 # Site settings
-title: "Devin AI Wiki for DevOps"
+title: "Devin AI DevOps Documentation"
 description: "Comprehensive documentation for using Devin AI with DevOps workflows, Infrastructure as Code, and OpenStack automation"
 baseurl: "/devin-ai-wiki"
 url: "https://agnosticdba.github.io"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title | default: site.title }}</title>
+    <meta name="description" content="{{ page.description | default: site.description }}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.2.0/github-markdown-light.min.css">
+    <style>
+      .markdown-body {
+        box-sizing: border-box;
+        min-width: 200px;
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 45px;
+      }
+      @media (max-width: 767px) {
+        .markdown-body {
+          padding: 15px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="markdown-body">
+      {{ content }}
+    </div>
+  </body>
+</html>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Devin AI Wiki for DevOps Workflows
+# Documentation Overview
 
 Welcome to the comprehensive Devin AI documentation tailored specifically for DevOps, Infrastructure as Code, and cloud automation workflows. This wiki provides practical guidance for leveraging Devin AI to enhance your infrastructure automation, configuration management, and deployment processes.
 


### PR DESCRIPTION
- Changed site title from 'Devin AI Wiki for DevOps' to 'Devin AI DevOps Documentation' to reduce repetition
- Updated docs/README.md heading from 'Devin AI Wiki for DevOps Workflows' to 'Documentation Overview'
- Created custom Jekyll layout to prevent automatic navigation generation that was displaying all documentation links in one confusing line
- Layout uses clean GitHub markdown styling without cluttered header navigation
- Fixes the mind map-like appearance of header text reported by user